### PR TITLE
Add save-training toggle to parameters.yaml

### DIFF
--- a/parameters/parameters.yaml
+++ b/parameters/parameters.yaml
@@ -1,5 +1,6 @@
 folder: naics6-bees-counties
-features: 
+save-training: false
+features:
   data: industries
   startyear: 2017
   endyear: 2021


### PR DESCRIPTION
Added `save-training: false` to parameters.yaml to support conditional saving of training outputs from within Run Models Colab.

This aligns with the new notebook logic that reads this key and uses it to control saving of train/test split files.
