### PR TITLE
Move parameters.yaml entry to the top

### DIFF
--- a/parameters/parameter-paths.csv
+++ b/parameters/parameter-paths.csv
@@ -1,5 +1,5 @@
-﻿parameters-simple.yaml,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters-simple.yaml
-parameters.yaml,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters.yaml
+﻿parameters.yaml,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters.yaml
+parameters-simple.yaml,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters-simple.yaml
 Parameters for years,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters-years.yaml
 Industries by zip code,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters-zip.yaml
 Eye Blinks,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters-blinks.yaml


### PR DESCRIPTION
The first entry in parameter-paths.csv was parameters-simple.yaml which causes the join of features with targets to give 16 records all belonging to a single class. This is not only suboptimal but also breaks the code as SMOTE requires more than one class. The next parameters.yaml entry works perfectly hence this PR makes it the default.