### PR TITLE
Add MN all-years bees parameters and register in parameter paths

### DIFF
--- a/parameters/parameter-paths.csv
+++ b/parameters/parameter-paths.csv
@@ -4,3 +4,4 @@ Forest Canopy (All States),https://raw.githubusercontent.com/ModelEarth/RealityS
 Google Data Commons (GDC),https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters-gdc.yaml
 Industries by Zip Code,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters-zip.yaml
 Eye Blinks,https://raw.githubusercontent.com/ModelEarth/RealityStream/main/parameters/parameters-blinks.yaml
+Bee All-Years (MN),https://raw.githubusercontent.com/ThousifMd/realitystream/main/parameters/parameters-all-years-bees-MN.yaml

--- a/parameters/parameters-all-years-bees-MN.yaml
+++ b/parameters/parameters-all-years-bees-MN.yaml
@@ -1,0 +1,19 @@
+# Parameters for All-Years Bee Data (Minnesota)
+# Extends the existing RealityStream parameter structure for NAICS6 features
+
+features:
+  path: "https://raw.githubusercontent.com/ModelEarth/community-timelines/main/training/all-years/naics6/MN-all-years.csv"
+  id: "Fips"
+
+targets:
+  path: "https://raw.githubusercontent.com/ModelEarth/bee-data/main/targets/bees-targets-top-20-percent.csv"
+  id: "Fips"
+  column: "colony_density_top_20"
+
+join:
+  key: "Fips"
+  how: "inner"
+
+models:
+  - RFC
+  - XGBoost


### PR DESCRIPTION
### Summary
Added a new parameters YAML file for the Minnesota (MN) all-years bee dataset using NAICS6 industry features. This configuration supports running multi-year models with the same pipeline used for other bee and GDC datasets.

### Details
- Added `parameters/parameters-all-years-bees-MN.yaml`
  - Features sourced from community-timelines: `training/all-years/naics6/MN-all-years.csv`
  - Targets sourced from bee-data: `bees-targets-top-20-percent.csv`
  - Join performed on Fips
- Registered the new config in `parameters/parameter-paths.csv`
  - Appears in the Colab dropdown as **"Bee All-Years (MN)"**
- Runs **RFC** and **XGBoost** models, consistent with `parameters-gdc.yaml`.

### Purpose
This addition enables the RealityStream pipeline to process Minnesota’s full multi-year bee dataset, supporting future comparisons across states and years while keeping the model setup aligned with existing configurations.
